### PR TITLE
Adding One Observability Demo Workshop

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ choose between innovation and control—they can have both._
 - [Management Tools Immersion Day](https://workshop.aws-management.tools)
 - [Open Distro for Elasticsearch](https://reinvent.aesworkshops.com/opn302/)
 - [AWS Systems Manager and AWS Config](https://ako.aws-management.tools/tko372759/en/ssm.html)
+- [One Observability Demo](https://observability.workshop.aws/)
 
 ## Media
 


### PR DESCRIPTION
This adds this awesome workshop on observability at AWS

# What is this workshop about

This workshop is aimed at providing an hands-on experience for you on the wide variety of toolsets AWS offers to setup monitoring and observability on your applications.

## Describe the services involved

* AWS X-Ray
* Amazon CloudWatch

## What is the category

Pick one of the existing ones at the main page, or Add a new one

- Management Tools

--

Anyone who agrees with this pull request could submit an :+1: for the owners to review.
