### PR TITLE
Added fargate workshop

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ to run their containers on AWS because of our security, reliability, and scalabi
 - [AWS App Mesh with Amazon EKS Workshop](https://app-mesh-eks-workshop.cloudfiles.me/)
 - [Blue Green Deployment with Amazon EKS and K8s](https://awsdemoworkshops.s3.us-east-2.amazonaws.com/cicd-eks-alb-bg-cdk-workshop/public/en/index.html)
 - [Container Security](https://container-devsecops.awssecworkshops.com/)
+- [ECS Fargate Workshop](https://ecs-fargate-dev-ops-data.workshop.aws/)
 - [EKS/ECR/ECS Modernization](https://modernize.awsworkshop.io/)
 - [GitOps Helm Workshop](https://helm.workshop.flagger.dev/)
 - [Integrating security into your container pipeline](https://container-devsecops.awssecworkshops.com/)


### PR DESCRIPTION
# What is this workshop about

This workshop has 3 different paths a user can take:

ECS Fargate for Developers - This module shows you how to deploy a typical microservice into an ECS Fargate cluster using a CI/CD pipeline that includes best practices for security and deployments.

ECS Fargate for Operators - This module shows you how to scale, secure, and troubleshoot an ECS Fargate cluster.

ECS Fargate for Data Engineers - This module shows you how to use ECS Fargate for batch and stream processing in a data pipeline.

## Describe the services involved

ECS Fagate, CDK, CloudFromation, CodeDeploy

## What is the category

Pick one of the existing ones at the main page, or Add a new one

Containers

--

Anyone who agrees with this pull request could submit an :+1: for the owners to review.
