### PR TITLE
Update AWS CloudFormation Workshop URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ members before deploying into production._
 - [AWS CDK Workshop](https://cdkworkshop.com/)
 - [AWS CloudFormation Best Practices:](http://workshop.quickstart.awspartner.com/)
 - [AWS CloudFormation Workshop for Partners](https://workshop.quickstart.awspartner.com/)
-- [AWS CloudFormation Workshop](https://cfn101.solution.builders/)
+- [AWS CloudFormation Workshop](https://cfn101.sa.engineering/)
 - [Modern Infrastructure as Code with Pulumi](https://pulumi.awsworkshop.io/)
 
 ## Infrastructure


### PR DESCRIPTION
# Update CloudFormation Workshop URL


This PR updates the AWS CloudFormation workshop URL.
The new URL is the same content (same cloudfront distribution), and still directs to the same content, but through a different domain. My team would prefer people to use the new domain 🙂


Anyone who agrees with this pull request could submit an :+1: for the owners to review.
